### PR TITLE
Fix support for using clang on Mac OS X

### DIFF
--- a/src/libprimer3.cc
+++ b/src/libprimer3.cc
@@ -47,10 +47,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ctype.h> /* toupper */
 #include <unordered_map>
 
+#ifdef __GLIBCXX__
 namespace std
 {
   using namespace __gnu_cxx;
 }
+#endif
 
 #include "libprimer3.h"
 


### PR DESCRIPTION
Compilation error before fix:
```
g++ -c -g -Wall -O2 -std=c++11  -o libprimer3.o libprimer3.cc
libprimer3.cc:53:19: error: expected namespace name
  using namespace __gnu_cxx;
                  ^
1 error generated.
```
CC lang version: Apple LLVM version 9.0.0 (clang-900.0.39.2)