### PR TITLE
Fix out of bounce read in oligotm

### DIFF
--- a/src/oligotm.c
+++ b/src/oligotm.c
@@ -96,7 +96,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 /* Table 1 (old parameters):
- * See table 2 in the paper [Breslauer KJ, Frank R, Blöcker H and
+ * See table 2 in the paper [Breslauer KJ, Frank R, Blï¿½cker H and
  * Marky LA (1986) "Predicting DNA duplex stability from the base
  * sequence" Proc Natl Acad Sci 83:4746-50
  * http://dx.doi.org/10.1073/pnas.83.11.3746]
@@ -583,7 +583,7 @@ DONE:  /* dg is now computed for the given sequence. */
 }
 
 double end_oligodg(const char *s,  
-  int len, /* The number of characters to return. */
+  size_t len, /* The number of characters to return. */
   int tm_method)
 {
   int x = strlen(s);

--- a/src/oligotm.c
+++ b/src/oligotm.c
@@ -96,7 +96,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 /* Table 1 (old parameters):
- * See table 2 in the paper [Breslauer KJ, Frank R, Bl�cker H and
+ * See table 2 in the paper [Breslauer KJ, Frank R, Blöcker H and
  * Marky LA (1986) "Predicting DNA duplex stability from the base
  * sequence" Proc Natl Acad Sci 83:4746-50
  * http://dx.doi.org/10.1073/pnas.83.11.3746]

--- a/src/oligotm.h
+++ b/src/oligotm.h
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* Return the delta G of the last len bases of oligo if oligo is at least len
    bases long; otherwise return the delta G of oligo. */
-double end_oligodg(const char *oligo, int len, int tm_method);
+double end_oligodg(const char *oligo, size_t len, int tm_method);
 
 /* Calculate the melting temperature of substr(seq, start, length) using the
    formula from Bolton and McCarthy, PNAS 84:1390 (1962) as presented in
@@ -119,7 +119,7 @@ typedef enum salt_correction_type {
    amplification in vitro", Nucleic Acids Res 18:6409-12
    http://www.pubmedcentral.nih.gov/articlerender.fcgi?tool=pubmed&pubmedid=2243783].
    and the thermodynamic parameters in the paper [Breslauer KJ, Frank
-   R, Blöcker H and Marky LA (1986) "Predicting DNA duplex stability
+   R, Blï¿½cker H and Marky LA (1986) "Predicting DNA duplex stability
    from the base sequence" Proc Natl Acad Sci 83:4746-50
    http://dx.doi.org/10.1073/pnas.83.11.3746], are is used.  This is
    the method and the table that primer3 used up to and including

--- a/src/oligotm.h
+++ b/src/oligotm.h
@@ -119,7 +119,7 @@ typedef enum salt_correction_type {
    amplification in vitro", Nucleic Acids Res 18:6409-12
    http://www.pubmedcentral.nih.gov/articlerender.fcgi?tool=pubmed&pubmedid=2243783].
    and the thermodynamic parameters in the paper [Breslauer KJ, Frank
-   R, Bl�cker H and Marky LA (1986) "Predicting DNA duplex stability
+   R, Blöcker H and Marky LA (1986) "Predicting DNA duplex stability
    from the base sequence" Proc Natl Acad Sci 83:4746-50
    http://dx.doi.org/10.1073/pnas.83.11.3746], are is used.  This is
    the method and the table that primer3 used up to and including


### PR DESCRIPTION
Calling the function `end_oligodg` with a negative length results in an out of bounce read:

```c
end_oligodg("ATTTCCGCCGTT", -5, 1);
```

![image](https://user-images.githubusercontent.com/46387399/131634000-4199b567-928b-4c9f-a6d2-c87d38ad2b9d.png)

In this example, the memory address of the sequence in the function `oligodg` is `0x005cc329` which is after the actual memory address of the sequence.

Using `size_t` instead of `int` for the parameter `len` will fix the issue because it only allows positive numbers and 0.