### PR TITLE
Fix unhandled errors of malloc

### DIFF
--- a/src/amplicontm.c
+++ b/src/amplicontm.c
@@ -159,6 +159,11 @@ amplicon_result amplicontm(const  char *inseq,
     int orilen = strlen(inseq);
     int gc_count = 0;
     ret.seq = (char *) malloc(sizeof(char) * (orilen + 1));
+    if ((ret.seq == NULL)) {
+        ret.error = 1;
+        amp_free_all(alloc_box, alloc_count);
+        return ret;
+    }
     for (i = 0 ; i < orilen ; i++) {
         ret.seq[ret.seq_len]=toupper(inseq[i]);
         switch(ret.seq[ret.seq_len]) {

--- a/src/libprimer3.cc
+++ b/src/libprimer3.cc
@@ -1164,29 +1164,33 @@ create_seq_arg()
 
 /* Free a seq_arg data structure */
 void
-destroy_seq_args(seq_args *sa) 
+destroy_seq_args(seq_args *sa)
 {
   if (NULL == sa) return;
-  free(sa->internal_input);
+
+  free(sa->quality);
+  free(sa->sequence);
+  free(sa->sequence_name);
+  free(sa->sequence_file);
+  free(sa->trimmed_seq);
+
+  /* edited by T. Koressaar for lowercase masking */
+  free(sa->trimmed_orig_seq);
+
+  free(sa->trimmed_masked_seq_r);
+  free(sa->trimmed_masked_seq);
+
+  free(sa->upcased_seq);
+  free(sa->upcased_seq_r);
+
   free(sa->left_input);
   free(sa->right_input);
-  free(sa->sequence);
-  free(sa->quality);
-  free(sa->trimmed_seq);
+  free(sa->internal_input);
 
   free(sa->overhang_left);
   free(sa->overhang_right);
   free(sa->overhang_right_rv);
 
-  /* edited by T. Koressaar for lowercase masking */
-  free(sa->trimmed_orig_seq);
-  
-  free(sa->trimmed_masked_seq_r);
-  free(sa->trimmed_masked_seq);
-  
-  free(sa->upcased_seq);
-  free(sa->upcased_seq_r);
-  free(sa->sequence_name);
   free(sa);
 }
 
@@ -4767,10 +4771,11 @@ align(const char *s1,
 /* Helper function */
 static int
 _set_string(char **loc, const char *new_string) {
-  if (*loc) {
-    free(*loc);
+  if (loc == NULL || *loc == NULL || new_string == NULL) {
+    return 1;
   }
-  if (!(*loc = (char *) malloc(strlen(new_string) + 1)))
+
+  if (!(*loc = (char *) realloc(*loc, strlen(new_string) + 1)))
     return 1; /* ENOMEM */
   strcpy(*loc, new_string);
   return 0;

--- a/src/libprimer3.h
+++ b/src/libprimer3.h
@@ -110,7 +110,7 @@ typedef enum p3_output_type {
 
 /* pr_append_str is an append-only string ADT. */
 typedef struct pr_append_str {
-  int storage_size;
+  size_t storage_size;
   char *data;
 } pr_append_str;
 

--- a/src/thal_main.c
+++ b/src/thal_main.c
@@ -337,6 +337,7 @@ int main(int argc, char** argv)
    if(interactive) {
      size_t buffer_size = 16384;
      char *oligo_str = (char*)malloc(sizeof(char)*buffer_size);
+     if (oligo_str == NULL) exit(-2);
 
      while(NULL != fgets(oligo_str, buffer_size, stdin)) {
        oligo_str[strlen(oligo_str)-1] = '\0';


### PR DESCRIPTION
The possibility that `malloc` returns `NULL` on failure wasn't handled properly at some places.