### PR TITLE
Update usage info to match ntthal defaults

### DIFF
--- a/src/thal_main.c
+++ b/src/thal_main.c
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
      "\n"
      "-dv divalent_conc    - concentration of divalent cations in mM, by default 0 mM\n"
      "\n"
-     "-n  dNTP_conc        - concentration of deoxynycleotide triphosphate in mM, by default 0 mM\n"
+     "-n  dNTP_conc        - concentration of deoxynycleotide triphosphate in mM, by default 0.8 mM\n"
      "\n"
      "-d  dna_conc         - concentration of DNA strands in nM, by default 50 nM\n"
      "\n"


### PR DESCRIPTION
Proposed fix for https://github.com/primer3-org/primer3/issues/79; updates usage information of `dNTP conc` in thal_main.c to match `set_thal_default_args` in thal.c