### PR TITLE
Reorganizing code and improving performance for dimer alignments in thal

### DIFF
--- a/src/thal.c
+++ b/src/thal.c
@@ -556,16 +556,18 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
       H = stackint2Enthalpies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
         stackint2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]];
    } else { /* only internal loops */
-      H = interiorLoopEnthalpies[loopSize] + tstack2Enthalpies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
-        tstack2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]]
-        + (ILAH * abs(loopSize1 - loopSize2));
-
-      S = interiorLoopEntropies[loopSize] + tstack2Entropies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
-        tstack2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] + (ILAS * abs(loopSize1 - loopSize2));
-      //This check just makes it so that the tstackEnthalpies/Entropies are not needed.
+      //Only calculate H and S if there is a mismatch in both nearest neighbor stacks. 
+      //This removes the need for the tstack table and improves performance.
+      //At this point, i,j and ii,jj are known to be complementary, so only need to check neighbors.
       //The only difference between tstack and tstack2 tables is when both pairs are complementary
-      if((is_complement[numSeq1[ii]][numSeq2[jj]] && is_complement[numSeq1[ii-1]][numSeq2[jj-1]]) || (is_complement[numSeq1[i]][numSeq2[j]] && is_complement[numSeq1[i+1]][numSeq2[j+1]]))
-         H = _INFINITY;
+      if((!is_complement[numSeq1[ii-1]][numSeq2[jj-1]]) && (!is_complement[numSeq1[i+1]][numSeq2[j+1]])){
+         H = interiorLoopEnthalpies[loopSize] + tstack2Enthalpies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
+         tstack2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]]
+         + (ILAH * abs(loopSize1 - loopSize2));
+
+         S = interiorLoopEntropies[loopSize] + tstack2Entropies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
+         tstack2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] + (ILAS * abs(loopSize1 - loopSize2));
+      }
    }
 
    EntropyEnthalpy[0] = S + entropyDPT[i][j];;

--- a/src/thal.c
+++ b/src/thal.c
@@ -126,7 +126,7 @@ static void fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpy
                                  double dplx_init_S, double dplx_init_H, const unsigned char *numSeq1,
                                  const unsigned char *numSeq2, int oligo1_len, int oligo2_len, thal_results* o);
 static void calc_bulge_internal_dimer(int ii, int jj, int i, int j, double* EntropyEnthalpy, const double *saved_RSH,
-                                 int traceback, int maxLoop, const double *const *entropyDPT, const double *const *enthalpyDPT,
+                                 int maxLoop, const double *const *entropyDPT, const double *const *enthalpyDPT,
                                  double RC, double dplx_init_S, double dplx_init_H,
                                  const unsigned char *numSeq1, const unsigned char *numSeq2);
 static void traceback_dimer(int i, int j, int* ps1, int* ps2, const struct vec2 **traceback_matrix);
@@ -562,7 +562,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                      SH[0] = -1.0;
                      SH[1] = _INFINITY;
                      if (isFinite(enthalpyDPT[ii][jj])) {
-                        calc_bulge_internal_dimer(ii, jj, i, j, SH, saved_RSH, 0, maxLoop, (const double **)entropyDPT, (const double **)enthalpyDPT, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
+                        calc_bulge_internal_dimer(ii, jj, i, j, SH, saved_RSH, maxLoop, (const double **)entropyDPT, (const double **)enthalpyDPT, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
                         if(SH[0] < MinEntropyCutoff) {
                            /* to not give dH any value if dS is unreasonable */
                            SH[0] = MinEntropy;
@@ -589,7 +589,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
 
 static void 
 calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy, const double *saved_RSH,
-                        int traceback, int maxLoop, const double *const *entropyDPT,  const double *const *enthalpyDPT, double RC,
+                        int maxLoop, const double *const *entropyDPT,  const double *const *enthalpyDPT, double RC,
                         double dplx_init_S, double dplx_init_H, const unsigned char *numSeq1, const unsigned char *numSeq2)
 {
    int loopSize1, loopSize2, loopSize;
@@ -622,12 +622,12 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
             H = _INFINITY;
             S = -1.0;
          } 
-         if((isFinite(H)) || (traceback==1)) {
+         if(isFinite(H)) {
             SH[0] = saved_RSH[0];
             SH[1] = saved_RSH[1];
             G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
             G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*((entropyDPT[ii][jj]+SH[0]));
-            if((G1< G2) || (traceback==1)) {
+            if(G1< G2) {
                EntropyEnthalpy[0] = S;
                EntropyEnthalpy[1] = H;
             }
@@ -647,12 +647,12 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
             H = _INFINITY;
             S = -1.0;
          }
-         if((isFinite(H)) || (traceback==1)){ 
+         if(isFinite(H)){ 
             SH[0] = saved_RSH[0];
             SH[1] = saved_RSH[1];
             G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
             G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*(entropyDPT[ii][jj]+SH[0]);
-            if(G1< G2 || (traceback==1)){
+            if(G1< G2){
                EntropyEnthalpy[0] = S;
                EntropyEnthalpy[1] = H;
             }
@@ -674,12 +674,12 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
          H = _INFINITY;
          S = -1.0;
       }    
-      if((isFinite(H)) || (traceback==1)){
+      if(isFinite(H)){
          SH[0] = saved_RSH[0];
          SH[1] = saved_RSH[1];
          G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
          G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*(entropyDPT[ii][jj]+SH[0]);
-         if((G1< G2) || traceback==1) {
+         if(G1< G2) {
             EntropyEnthalpy[0] = S;
             EntropyEnthalpy[1] = H;
          }
@@ -702,12 +702,12 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
          H = _INFINITY;
          S = -1.0;
       }
-      if((isFinite(H)) || (traceback==1)){
+      if(isFinite(H)){
          SH[0] = saved_RSH[0];
          SH[1] = saved_RSH[1];
          G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
          G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*(entropyDPT[ii][jj]+SH[0]);
-         if((G1< G2) || (traceback==1)){
+         if(G1< G2){
                   EntropyEnthalpy[0] = S;
                   EntropyEnthalpy[1] = H;
             }

--- a/src/thal.c
+++ b/src/thal.c
@@ -618,7 +618,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    S1 = S2 = -1.0;
    H1 = H2 = -_INFINITY;
    T1 = T2 = -_INFINITY;
-   
+
    S1 = atpS[numSeq1[i]][numSeq2[j]] + tstack2Entropies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
    H1 = atpH[numSeq1[i]][numSeq2[j]] + tstack2Enthalpies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
    G1 = H1 - TEMP_KELVIN*S1;
@@ -628,73 +628,75 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
       G1 = 1.0;
    }
    /** If there is two dangling ends at the same end of duplex **/
-   if((is_complement[numSeq1[i-1]][numSeq2[j-1]] != 1 ) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
-      S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
-        dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-      H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
-        dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-      G2 = H2 - TEMP_KELVIN*S2;
-      if(G2>0) {
-         H2 = _INFINITY;
-         S2 = -1.0;
-     G2 = 1.0;
-      }
-      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-      if(isFinite(H1) && G1<0) {
-         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-         if(T1<T2 && G2<0) {
+   if(!is_complement[numSeq1[i-1]][numSeq2[j-1]]){
+      if(isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
+         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
+         dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
+         dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+         G2 = H2 - TEMP_KELVIN*S2;
+         if(G2>0) {
+            H2 = _INFINITY;
+            S2 = -1.0;
+      G2 = 1.0;
+         }
+         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+         if(isFinite(H1) && G1<0) {
+            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+            if(T1<T2 && G2<0) {
+               S1 = S2;
+               H1 = H2;
+               T1 = T2;
+            }
+         } else if(G2<0) {
             S1 = S2;
             H1 = H2;
             T1 = T2;
          }
-      } else if(G2<0) {
-         S1 = S2;
-         H1 = H2;
-         T1 = T2;
-      }
-   } else if ((is_complement[numSeq1[i-1]][numSeq2[j-1]] != 1) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
-      S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
-      H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
-      G2 = H2 - TEMP_KELVIN*S2;
-      if(G2>0) {
-         H2 = _INFINITY;
-         S2 = -1.0;
-     G2 = 1.0;
-      }
-      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-      if(G1<0) {
-         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-         if(T1<T2 && G2<0) {
+      } else if (isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
+         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
+         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
+         G2 = H2 - TEMP_KELVIN*S2;
+         if(G2>0) {
+            H2 = _INFINITY;
+            S2 = -1.0;
+      G2 = 1.0;
+         }
+         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+         if(G1<0) {
+            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+            if(T1<T2 && G2<0) {
+               S1 = S2;
+               H1 = H2;
+               T1 = T2;
+            }
+         } else if (G2<0){
             S1 = S2;
             H1 = H2;
             T1 = T2;
          }
-      } else if (G2<0){
-         S1 = S2;
-         H1 = H2;
-         T1 = T2;
-      }
-   } else if ((is_complement[numSeq1[i-1]][numSeq2[j-1]] != 1) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
-      S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-      H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-      G2 = H2 - TEMP_KELVIN*S2;
-      if(G2>0) {
-         H2 = _INFINITY;
-         S2 = -1.0;
-     G2 = 1.0;     
-      }
-      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-      if(G1<0) {
-         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-         if(T1 < T2  && G2<0) {
+      } else if (isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
+         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+         G2 = H2 - TEMP_KELVIN*S2;
+         if(G2>0) {
+            H2 = _INFINITY;
+            S2 = -1.0;
+      G2 = 1.0;     
+         }
+         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+         if(G1<0) {
+            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+            if(T1 < T2  && G2<0) {
+               S1 = S2;
+               H1 = H2;
+               T1 = T2;
+            }
+         } else if(G2<0) {
             S1 = S2;
             H1 = H2;
             T1 = T2;
          }
-      } else if(G2<0) {
-         S1 = S2;
-         H1 = H2;
-         T1 = T2;
       }
    }
    S2 = atpS[numSeq1[i]][numSeq2[j]];
@@ -745,80 +747,83 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
       G1 = 1.0;
    }
    
-   if(is_complement[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
-      S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
-        dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-      H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
-        dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-    G2 = H2 - TEMP_KELVIN*S2;
-      if(G2>0) {
-         H2 = _INFINITY;
-         S2 = -1.0;
-     G2 = 1.0;
-      }
-      
-      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-      if(G1<0) {
-         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-         if(T1 < T2 && G2<0) {
+   if(!is_complement[numSeq1[i+1]][numSeq2[j+1]]){
+      if(isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
+         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
+         dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
+         dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+      G2 = H2 - TEMP_KELVIN*S2;
+         if(G2>0) {
+            H2 = _INFINITY;
+            S2 = -1.0;
+      G2 = 1.0;
+         }
+         
+         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+         if(G1<0) {
+            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+            if(T1 < T2 && G2<0) {
+               S1 = S2;
+               H1 = H2;
+               T1 = T2;
+            }
+         } else if(G2<0){
             S1 = S2;
             H1 = H2;
             T1 = T2;
          }
-      } else if(G2<0){
-         S1 = S2;
-         H1 = H2;
-         T1 = T2;
+      }
+
+      else if(isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])) {
+         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
+         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
+         G2 = H2 - TEMP_KELVIN*S2;
+         if(G2 >0) {
+            H2 = _INFINITY;
+            S2 = -1.0;
+            G2 = 1.0;
+         }
+         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+         if(G1<0) {
+            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+            if(T1 < T2 && G2<0) {
+               S1 = S2;
+               H1 = H2;
+               T1 = T2;
+            }
+         } else if(G2<0){
+            S1 = S2;
+            H1 = H2;
+            T1 = T2;
+         }
+      }
+
+      else if(isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
+         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+         G2 = H2 - TEMP_KELVIN*S2;
+         if(G2>0) {
+            H2 = _INFINITY;
+            S2 = -1.0;
+      G2 = 1.0;
+         }
+         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+         if(G1<0) {
+            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+            if(T1 < T2 && G2<0) {
+               S1 = S2;
+               H1 = H2;
+               T1 = T2;
+            }
+         } else if (G2<0){
+            S1 = S2;
+            H1 = H2;
+            T1 = T2;
+         }
       }
    }
 
-   else if(is_complement[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])) {
-      S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
-      H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
-      G2 = H2 - TEMP_KELVIN*S2;
-      if(G2 >0) {
-         H2 = _INFINITY;
-         S2 = -1.0;
-         G2 = 1.0;
-      }
-      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-      if(G1<0) {
-         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-         if(T1 < T2 && G2<0) {
-            S1 = S2;
-            H1 = H2;
-            T1 = T2;
-         }
-      } else if(G2<0){
-         S1 = S2;
-         H1 = H2;
-         T1 = T2;
-      }
-   }
-
-   else if(is_complement[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
-      S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-      H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-      G2 = H2 - TEMP_KELVIN*S2;
-      if(G2>0) {
-         H2 = _INFINITY;
-         S2 = -1.0;
-     G2 = 1.0;
-      }
-      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-      if(G1<0) {
-         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-         if(T1 < T2 && G2<0) {
-            S1 = S2;
-            H1 = H2;
-            T1 = T2;
-         }
-      } else if (G2<0){
-         S1 = S2;
-         H1 = H2;
-         T1 = T2;
-      }
-   }
    S2 = atpS[numSeq1[i]][numSeq2[j]];
    H2 = atpH[numSeq1[i]][numSeq2[j]];
    T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);

--- a/src/thal.c
+++ b/src/thal.c
@@ -126,8 +126,7 @@ static void fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpy
                                  double dplx_init_S, double dplx_init_H, const unsigned char *numSeq1,
                                  const unsigned char *numSeq2, int oligo1_len, int oligo2_len, thal_results* o);
 static void calc_bulge_internal_dimer(int ii, int jj, int i, int j, double* EntropyEnthalpy, const double *saved_RSH,
-                                 int maxLoop, const double *const *entropyDPT, const double *const *enthalpyDPT,
-                                 double RC, double dplx_init_S, double dplx_init_H,
+                                 const double *const *entropyDPT, const double *const *enthalpyDPT,
                                  const unsigned char *numSeq1, const unsigned char *numSeq2);
 static void traceback_dimer(int i, int j, int* ps1, int* ps2, const struct vec2 **traceback_matrix);
 char *drawDimer(int*, int*, double, double, const thal_mode mode, double, const unsigned char *oligo1, const unsigned char *oligo2,
@@ -562,7 +561,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                      SH[0] = -1.0;
                      SH[1] = _INFINITY;
                      if (isFinite(enthalpyDPT[ii][jj])) {
-                        calc_bulge_internal_dimer(ii, jj, i, j, SH, saved_RSH, maxLoop, (const double **)entropyDPT, (const double **)enthalpyDPT, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
+                        calc_bulge_internal_dimer(ii, jj, i, j, SH, saved_RSH, (const double **)entropyDPT, (const double **)enthalpyDPT, numSeq1, numSeq2);
                         if(SH[0] < MinEntropyCutoff) {
                            /* to not give dH any value if dS is unreasonable */
                            SH[0] = MinEntropy;
@@ -589,8 +588,8 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
 
 static void 
 calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy, const double *saved_RSH,
-                        int maxLoop, const double *const *entropyDPT,  const double *const *enthalpyDPT, double RC,
-                        double dplx_init_S, double dplx_init_H, const unsigned char *numSeq1, const unsigned char *numSeq2)
+                        const double *const *entropyDPT,  const double *const *enthalpyDPT,
+                        const unsigned char *numSeq1, const unsigned char *numSeq2)
 {
    int loopSize1, loopSize2, loopSize;
    double S,H,G1,G2;

--- a/src/thal.c
+++ b/src/thal.c
@@ -500,7 +500,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                      jj = 1;
                   }
                   for (; ii > 0 && jj < j; --ii, ++jj) {
-                     if(is_complement[numSeq1[ii]][numSeq2[jj]]){// (isFinite(enthalpyDPT[ii][jj])) {
+                     if(is_complement[numSeq1[ii]][numSeq2[jj]]){
                         calc_bulge_internal_dimer(ii, jj, i, j, SH, (const double **)entropyDPT, (const double **)enthalpyDPT, numSeq1, numSeq2);
                         newG = SH[1]+saved_RSH[1] -TEMP_KELVIN*(SH[0]+saved_RSH[0]);
                         if(newG < bestG ) {

--- a/src/thal.c
+++ b/src/thal.c
@@ -618,11 +618,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    S1 = S2 = -1.0;
    H1 = H2 = -_INFINITY;
    T1 = T2 = -_INFINITY;
-   if (is_complement[numSeq1[i]][numSeq2[j]] == 0) {
-      EntropyEnthalpy[0] = -1.0;
-      EntropyEnthalpy[1] = _INFINITY;
-      return;
-   }
+   
    S1 = atpS[numSeq1[i]][numSeq2[j]] + tstack2Entropies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
    H1 = atpH[numSeq1[i]][numSeq2[j]] + tstack2Enthalpies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
    G1 = H1 - TEMP_KELVIN*S1;

--- a/src/thal.c
+++ b/src/thal.c
@@ -407,42 +407,32 @@ thal(const unsigned char *oligo_f,
       initMatrix_dimer(entropyDPT, enthalpyDPT, numSeq1, numSeq2, oligo1_len, oligo2_len);
       fillMatrix_dimer(a->maxLoop, entropyDPT, enthalpyDPT, traceback_matrix, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2, oligo1_len, oligo2_len, o);
       /* calculate terminal basepairs */
-      bestI = bestJ = 0; 
+      bestI = bestJ = 1; 
       G1 = bestG = _INFINITY;
-      if(a->type==1) {
-         for (i = 1; i <= oligo1_len; i++) {
-            for (j = 1; j <= oligo2_len; j++) {
-               RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
-               G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
-               if(G1<bestG){
-                  bestG = G1;
-                  bestI = i;
-                  bestJ = j;
-               }
-            }
-         }
-      } else {
-         /* THAL_END1 */
-         bestI = bestJ = 0;
-         bestI = oligo1_len;
-         i = oligo1_len;
-         G1 = bestG = _INFINITY;
-         for (j = 1; j <= oligo2_len; ++j) {
+
+      if(a->type==1)
+         i = 1;
+      else
+         i = oligo1_len; //THAL_END1: oligo1 3' end must be part of terminal pair
+
+      for (; i <= oligo1_len; i++) {
+         for (j = 1; j <= oligo2_len; j++) {
             RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
             G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
-               if(G1<bestG){
+            if(G1<bestG){
                bestG = G1;
+               bestI = i;
                bestJ = j;
             }
          }
       }
-      if (!isFinite(bestG)) bestI = bestJ = 1;
-      double dH, dS;
-      RSH(bestI, bestJ, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
-      dH = enthalpyDPT[bestI][bestJ]+ SH[1] + dplx_init_H;
-      dS = (entropyDPT[bestI][bestJ] + SH[0] + dplx_init_S);
+      
       /* tracebacking */
       if(isFinite(enthalpyDPT[bestI][bestJ])){
+         double dH, dS;
+         RSH(bestI, bestJ, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
+         dH = enthalpyDPT[bestI][bestJ]+ SH[1] + dplx_init_H;
+         dS = (entropyDPT[bestI][bestJ] + SH[0] + dplx_init_S);
          traceback_dimer(bestI, bestJ, ps1, ps2, (const struct vec2 **)traceback_matrix);
          o->sec_struct=drawDimer(ps1, ps2, dH, dS, mode, a->temp, oligo1, oligo2, saltCorrection, RC, oligo1_len, oligo2_len, _jmp_buf, o);
          o->align_end_1=bestI;

--- a/src/thal.c
+++ b/src/thal.c
@@ -594,124 +594,49 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
 {
    int loopSize1, loopSize2, loopSize;
    double S,H,G1,G2;
-   double SH[2];
-   SH[0] = -1.0;
-   SH[1] = _INFINITY;
    S = -1.0;
    H = _INFINITY;
    loopSize1 = ii - i - 1;
    loopSize2 = jj - j - 1;
    loopSize = loopSize1 + loopSize2-1;
-   if((loopSize1 == 0 && loopSize2 > 0) || (loopSize2 == 0 && loopSize1 > 0)) { /* only bulges have to be considered */
+   if(loopSize1 == 0 || loopSize2 == 0) { /* only bulges have to be considered */
       if(loopSize2 == 1 || loopSize1 == 1) { /* bulge loop of size one is treated differently
                                               the intervening nn-pair must be added */
+         H = bulgeLoopEnthalpies[loopSize] +
+            stackEnthalpies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
 
-         if((loopSize2 == 1 && loopSize1 == 0) || (loopSize2 == 0 && loopSize1 == 1)) {
-            H = bulgeLoopEnthalpies[loopSize] +
-              stackEnthalpies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
-            S = bulgeLoopEntropies[loopSize] +
-              stackEntropies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
-         }
-         if((H > 0) || (S > 0)){
-            H = _INFINITY;
-            S = -1.0;
-         }
-         H += enthalpyDPT[i][j];
-         S += entropyDPT[i][j];
-         if(!isFinite(H)) {
-            H = _INFINITY;
-            S = -1.0;
-         } 
-         if(isFinite(H)) {
-            SH[0] = saved_RSH[0];
-            SH[1] = saved_RSH[1];
-            G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
-            G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*((entropyDPT[ii][jj]+SH[0]));
-            if(G1< G2) {
-               EntropyEnthalpy[0] = S;
-               EntropyEnthalpy[1] = H;
-            }
-         }
+         S = bulgeLoopEntropies[loopSize] +
+            stackEntropies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
       } else { /* we have _not_ implemented Jacobson-Stockaymayer equation; the maximum bulgeloop size is 30 */
 
          H = bulgeLoopEnthalpies[loopSize] + atpH[numSeq1[i]][numSeq2[j]] + atpH[numSeq1[ii]][numSeq2[jj]];
-         H += enthalpyDPT[i][j];
 
          S = bulgeLoopEntropies[loopSize] + atpS[numSeq1[i]][numSeq2[j]] + atpS[numSeq1[ii]][numSeq2[jj]];
-         S += entropyDPT[i][j];
-         if(!isFinite(H)) {
-            H = _INFINITY;
-            S = -1.0;
-         }
-         if((H > 0) && (S > 0)){ 
-            H = _INFINITY;
-            S = -1.0;
-         }
-         if(isFinite(H)){ 
-            SH[0] = saved_RSH[0];
-            SH[1] = saved_RSH[1];
-            G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
-            G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*(entropyDPT[ii][jj]+SH[0]);
-            if(G1< G2){
-               EntropyEnthalpy[0] = S;
-               EntropyEnthalpy[1] = H;
-            }
-         }
       }
    } else if (loopSize1 == 1 && loopSize2 == 1) {
       S = stackint2Entropies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
         stackint2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]];
-      S += entropyDPT[i][j];
 
       H = stackint2Enthalpies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
         stackint2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]];
-      H += enthalpyDPT[i][j];
-      if(!isFinite(H)) {
-         H = _INFINITY;
-         S = -1.0;
-      }
-      if((H > 0) && (S > 0)){
-         H = _INFINITY;
-         S = -1.0;
-      }    
-      if(isFinite(H)){
-         SH[0] = saved_RSH[0];
-         SH[1] = saved_RSH[1];
-         G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
-         G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*(entropyDPT[ii][jj]+SH[0]);
-         if(G1< G2) {
-            EntropyEnthalpy[0] = S;
-            EntropyEnthalpy[1] = H;
-         }
-      }
-      return;
    } else { /* only internal loops */
       H = interiorLoopEnthalpies[loopSize] + tstackEnthalpies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
         tstackEnthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]]
         + (ILAH * abs(loopSize1 - loopSize2));
-      H += enthalpyDPT[i][j];
 
       S = interiorLoopEntropies[loopSize] + tstackEntropies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
         tstackEntropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] + (ILAS * abs(loopSize1 - loopSize2));
-      S += entropyDPT[i][j];
-      if(!isFinite(H)) {
-         H = _INFINITY;
-         S = -1.0;
+   }
+
+   H += enthalpyDPT[i][j];
+   S += entropyDPT[i][j];
+   if(!(((H > 0) && (S > 0)) || !isFinite(H))){ 
+      G1 = H+saved_RSH[1] -TEMP_KELVIN*(S+saved_RSH[0]);
+      G2 = enthalpyDPT[ii][jj]+saved_RSH[1]-TEMP_KELVIN*(entropyDPT[ii][jj]+saved_RSH[0]);
+      if(G1< G2){
+         EntropyEnthalpy[0] = S;
+         EntropyEnthalpy[1] = H;
       }
-   if((H > 0) && (S > 0)){ 
-         H = _INFINITY;
-         S = -1.0;
-      }
-      if(isFinite(H)){
-         SH[0] = saved_RSH[0];
-         SH[1] = saved_RSH[1];
-         G1 = H+SH[1] -TEMP_KELVIN*(S+SH[0]);
-         G2 = enthalpyDPT[ii][jj]+SH[1]-TEMP_KELVIN*(entropyDPT[ii][jj]+SH[0]);
-         if(G1< G2){
-                  EntropyEnthalpy[0] = S;
-                  EntropyEnthalpy[1] = H;
-            }
-         }
    }
    return;
 }

--- a/src/thal.c
+++ b/src/thal.c
@@ -496,7 +496,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                   ii = i - 1;
                   jj = - ii - d + (j + i);
                   if (jj < 1) {
-                     ii -= abs(jj-1);
+                     ii += jj-1;
                      jj = 1;
                   }
                   for (; ii > 0 && jj < j; --ii, ++jj) {

--- a/src/thal.c
+++ b/src/thal.c
@@ -342,8 +342,8 @@ thal(const unsigned char *oligo_f,
       reverse(oligo2); /* REVERSE oligo2, so it goes to dpt 3'->5' direction */
    }
    /* convert nucleotides to numbers */
-   numSeq1 = (unsigned char*) safe_realloc(numSeq1, oligo1_len + 2, _jmp_buf, o);
-   numSeq2 = (unsigned char*) safe_realloc(numSeq2, oligo2_len + 2, _jmp_buf, o);
+   numSeq1 = (unsigned char*) safe_malloc(oligo1_len + 2, _jmp_buf, o);
+   numSeq2 = (unsigned char*) safe_malloc(oligo2_len + 2, _jmp_buf, o);
 
    /*** Calc part of the salt correction ***/
    saltCorrection=saltCorrectS(a->mv,a->dv,a->dntp); /* salt correction for entropy, must be multiplied with N, which is
@@ -356,10 +356,8 @@ thal(const unsigned char *oligo_f,
    numSeq1[0] = numSeq1[oligo1_len + 1] = numSeq2[0] = numSeq2[oligo2_len + 1] = 4; /* mark as N-s */
 
    if (a->type==4) { /* calculate structure of monomer */
-      double *hend5 = NULL;
-      double *send5 = NULL;
-      send5 = (double*) safe_realloc(send5, (oligo1_len + 1) * sizeof(double), _jmp_buf, o);
-      hend5 = (double*) safe_realloc(hend5, (oligo1_len + 1) * sizeof(double), _jmp_buf, o);
+      double *hend5 = (double*) safe_malloc((oligo1_len + 1) * sizeof(double), _jmp_buf, o);
+      double *send5 = (double*) safe_malloc((oligo1_len + 1) * sizeof(double), _jmp_buf, o);
       initMatrix_monomer(entropyDPT, enthalpyDPT, numSeq1, numSeq2, oligo1_len, oligo2_len);
       fillMatrix_monomer(a->maxLoop, entropyDPT, enthalpyDPT, RC, numSeq1, numSeq2, oligo1_len, oligo2_len, o);
       calc_terminal_bp(a->temp, (const double **)entropyDPT, (const double **)enthalpyDPT, send5, hend5, RC, numSeq1, numSeq2, oligo1_len, oligo2_len);

--- a/src/thal.c
+++ b/src/thal.c
@@ -400,28 +400,28 @@ thal(const unsigned char *oligo_f,
       free(oligo2);
       return;
    } else if(a->type!=4) { /* Hybridization of two moleculs */
+      int *ps1, *ps2;
+      ps1 = (int*) safe_calloc(oligo1_len, sizeof(int), _jmp_buf, o);
+      ps2 = (int*) safe_calloc(oligo2_len, sizeof(int), _jmp_buf, o);
       struct vec2 **traceback_matrix = allocate_traceback_matrix(oligo1_len, oligo2_len, _jmp_buf, o);
       initMatrix_dimer(entropyDPT, enthalpyDPT, numSeq1, numSeq2, oligo1_len, oligo2_len);
       fillMatrix_dimer(a->maxLoop, entropyDPT, enthalpyDPT, traceback_matrix, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2, oligo1_len, oligo2_len, o);
       /* calculate terminal basepairs */
       bestI = bestJ = 0; 
       G1 = bestG = _INFINITY;
-      if(a->type==1)
-        for (i = 1; i <= oligo1_len; i++) {
-           for (j = 1; j <= oligo2_len; j++) {
-              RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
-              G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
-              if(G1<bestG){
-                 bestG = G1;
-                 bestI = i;
-                 bestJ = j;
-              }
-           }
-        }
-      int *ps1, *ps2;
-      ps1 = (int*) safe_calloc(oligo1_len, sizeof(int), _jmp_buf, o);
-      ps2 = (int*) safe_calloc(oligo2_len, sizeof(int), _jmp_buf, o);
-      if(a->type == 2 || a->type == 3)        {
+      if(a->type==1) {
+         for (i = 1; i <= oligo1_len; i++) {
+            for (j = 1; j <= oligo2_len; j++) {
+               RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
+               G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
+               if(G1<bestG){
+                  bestG = G1;
+                  bestI = i;
+                  bestJ = j;
+               }
+            }
+         }
+      } else {
          /* THAL_END1 */
          bestI = bestJ = 0;
          bestI = oligo1_len;
@@ -430,9 +430,9 @@ thal(const unsigned char *oligo_f,
          for (j = 1; j <= oligo2_len; ++j) {
             RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
             G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
-                if(G1<bestG){
-                   bestG = G1;
-                         bestJ = j;
+               if(G1<bestG){
+               bestG = G1;
+               bestJ = j;
             }
          }
       }

--- a/src/thal.c
+++ b/src/thal.c
@@ -404,18 +404,20 @@ thal(const unsigned char *oligo_f,
 
       for (; i <= oligo1_len; i++) {
          for (j = 1; j <= oligo2_len; j++) {
-            RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
-            G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
-            if(G1<bestG){
-               bestG = G1;
-               bestI = i;
-               bestJ = j;
+            if(bpIndx[numSeq1[i]][numSeq2[j]]){
+               RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
+               G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
+               if(G1<bestG){
+                  bestG = G1;
+                  bestI = i;
+                  bestJ = j;
+               }
             }
          }
       }
 
       /* tracebacking */
-      if(isFinite(enthalpyDPT[bestI][bestJ])){
+      if(bpIndx[numSeq1[bestI]][numSeq2[bestJ]]){
          double dH, dS;
          RSH(bestI, bestJ, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
          dH = enthalpyDPT[bestI][bestJ]+ SH[1] + dplx_init_H;

--- a/src/thal.c
+++ b/src/thal.c
@@ -421,13 +421,9 @@ thal(const unsigned char *oligo_f,
          RSH(bestI, bestJ, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
          traceback_dimer(bestI, bestJ, ps1, ps2, (const struct vec2 **)traceback_matrix);
          int N=0;
-         for(i=0;i<oligo1_len;i++){
+         for(i=0;i<oligo1_len;i++)
             if(ps1[i]>0) ++N;
-         }
-         for(i=0;i<oligo2_len;i++) {
-            if(ps2[i]>0) ++N;
-         }
-         N = (N/2) -1;
+         N--;
          o->dh = enthalpyDPT[bestI][bestJ]+ SH[1] + dplx_init_H;
          o->ds = (entropyDPT[bestI][bestJ] + SH[0] + dplx_init_S);
          o->ds = o->ds + (N * saltCorrection);

--- a/src/thal.c
+++ b/src/thal.c
@@ -491,7 +491,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                saved_RSH[0] = SH[0];
                saved_RSH[1] = SH[1];
                T0 = (H0 + dplx_init_H + SH[1]) /(S0 + dplx_init_S + SH[0] + RC); /* at current position */
-               
+
                if(isFinite(enthalpyDPT[i-1][j-1]) && isFinite(stackEnthalpies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]])) {
                   S1 = entropyDPT[i-1][j-1] + stackEntropies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]];
                   H1 = enthalpyDPT[i-1][j-1] + stackEnthalpies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]];
@@ -521,11 +521,6 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                      SH[1] = _INFINITY;
                      if (isFinite(enthalpyDPT[ii][jj])) {
                         calc_bulge_internal_dimer(ii, jj, i, j, SH, saved_RSH, (const double **)entropyDPT, (const double **)enthalpyDPT, numSeq1, numSeq2);
-                        if(SH[0] < MinEntropyCutoff) {
-                           /* to not give dH any value if dS is unreasonable */
-                           SH[0] = MinEntropy;
-                           SH[1] = 0.0;
-                        }
                         if(isFinite(SH[1])) {
                            //This condition is only here to pick the same alignment as the old traceback
                            //when there are multiple, equal alignments.

--- a/src/thal.c
+++ b/src/thal.c
@@ -638,7 +638,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
          if(G2>0) {
             H2 = _INFINITY;
             S2 = -1.0;
-      G2 = 1.0;
+            G2 = 1.0;
          }
          T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
          if(isFinite(H1) && G1<0) {
@@ -660,7 +660,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
          if(G2>0) {
             H2 = _INFINITY;
             S2 = -1.0;
-      G2 = 1.0;
+            G2 = 1.0;
          }
          T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
          if(G1<0) {
@@ -682,7 +682,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
          if(G2>0) {
             H2 = _INFINITY;
             S2 = -1.0;
-      G2 = 1.0;     
+            G2 = 1.0;     
          }
          T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
          if(G1<0) {
@@ -753,11 +753,11 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
          dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
          H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
          dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-      G2 = H2 - TEMP_KELVIN*S2;
+         G2 = H2 - TEMP_KELVIN*S2;
          if(G2>0) {
             H2 = _INFINITY;
             S2 = -1.0;
-      G2 = 1.0;
+            G2 = 1.0;
          }
          
          T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
@@ -806,7 +806,7 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
          if(G2>0) {
             H2 = _INFINITY;
             S2 = -1.0;
-      G2 = 1.0;
+            G2 = 1.0;
          }
          T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
          if(G1<0) {

--- a/src/thal.c
+++ b/src/thal.c
@@ -530,25 +530,21 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
    loopSize2 = jj - j - 1;
    loopSize = loopSize1 + loopSize2-1;
    if(loopSize1 == 0 || loopSize2 == 0) { /* only bulges have to be considered */
-      if(loopSize2 == 1 || loopSize1 == 1) { /* bulge loop of size one is treated differently
-                                              the intervening nn-pair must be added */
+      //bulge loop of size one is treated differently. the intervening nn-pair must be added
+      if(loopSize2 == 1 || loopSize1 == 1) {
          H = bulgeLoopEnthalpies[loopSize] +
-            stackEnthalpies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
-
+             stackEnthalpies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
          S = bulgeLoopEntropies[loopSize] +
-            stackEntropies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
+             stackEntropies[numSeq1[i]][numSeq1[ii]][numSeq2[j]][numSeq2[jj]];
       } else { /* we have _not_ implemented Jacobson-Stockaymayer equation; the maximum bulgeloop size is 30 */
-
          H = bulgeLoopEnthalpies[loopSize] + atpH[numSeq1[i]][numSeq2[j]] + atpH[numSeq1[ii]][numSeq2[jj]];
-
          S = bulgeLoopEntropies[loopSize] + atpS[numSeq1[i]][numSeq2[j]] + atpS[numSeq1[ii]][numSeq2[jj]];
       }
    } else if (loopSize1 == 1 && loopSize2 == 1) {
       S = stackint2Entropies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
-        stackint2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]];
-
+          stackint2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]];
       H = stackint2Enthalpies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
-        stackint2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]];
+          stackint2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]];
    } else { /* only internal loops */
       //Only calculate H and S if there is a mismatch in both nearest neighbor stacks. 
       //This removes the need for the tstack table and improves performance.
@@ -556,14 +552,13 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
       //The only difference between tstack and tstack2 tables is when both pairs are complementary
       if((!is_complement[numSeq1[ii-1]][numSeq2[jj-1]]) && (!is_complement[numSeq1[i+1]][numSeq2[j+1]])){
          H = interiorLoopEnthalpies[loopSize] + tstack2Enthalpies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
-         tstack2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]]
-         + (ILAH * abs(loopSize1 - loopSize2));
-
+             tstack2Enthalpies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] +
+             (ILAH * abs(loopSize1 - loopSize2));
          S = interiorLoopEntropies[loopSize] + tstack2Entropies[numSeq1[i]][numSeq1[i+1]][numSeq2[j]][numSeq2[j+1]] +
-         tstack2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] + (ILAS * abs(loopSize1 - loopSize2));
+             tstack2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] + 
+             (ILAS * abs(loopSize1 - loopSize2));
       }
    }
-
    EntropyEnthalpy[0] = S + entropyDPT[i][j];;
    EntropyEnthalpy[1] = H + enthalpyDPT[i][j];
    return;

--- a/src/thal.c
+++ b/src/thal.c
@@ -629,7 +629,8 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    }
    /** If there is two dangling ends at the same end of duplex **/
    if(!is_complement[numSeq1[i-1]][numSeq2[j-1]]){
-      if(isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
+      
+      if((numSeq1[i-1] != 4) && (numSeq2[j-1] != 4) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
          S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
          dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
          H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
@@ -653,7 +654,8 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
             H1 = H2;
             T1 = T2;
          }
-      } else if (isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
+      } else 
+       if ((numSeq1[i-1] == 4) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
          S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
          H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
          G2 = H2 - TEMP_KELVIN*S2;
@@ -675,7 +677,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
             H1 = H2;
             T1 = T2;
          }
-      } else if (isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
+      } else if ((numSeq2[j-1] == 4) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
          S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
          H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
          G2 = H2 - TEMP_KELVIN*S2;
@@ -741,86 +743,38 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    S1 = atpS[numSeq1[i]][numSeq2[j]] + tstack2Entropies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]];
    H1 = atpH[numSeq1[i]][numSeq2[j]] + tstack2Enthalpies[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]][numSeq2[j + 1]];
    G1 = H1 - TEMP_KELVIN*S1;
-   if(G1>0) {
-      H1 = _INFINITY;
-      S1 = -1.0;
-      G1 = 1.0;
-   }
    
    if(!is_complement[numSeq1[i+1]][numSeq2[j+1]]){
-      if(isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
-         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
-         dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
-         dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+      S2 = atpS[numSeq1[i]][numSeq2[j]];
+      H2 = atpH[numSeq1[i]][numSeq2[j]];
+      if((numSeq2[j+1] == 4)){
+         S2 += dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
+         H2 += dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
          G2 = H2 - TEMP_KELVIN*S2;
-         if(G2>0) {
-            H2 = _INFINITY;
-            S2 = -1.0;
-            G2 = 1.0;
-         }
-         
-         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-         if(G1<0) {
-            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-            if(T1 < T2 && G2<0) {
-               S1 = S2;
-               H1 = H2;
-               T1 = T2;
-            }
-         } else if(G2<0){
-            S1 = S2;
-            H1 = H2;
-            T1 = T2;
-         }
+      } else if((numSeq1[i+1] == 4)){
+         S2 += dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+         H2 += dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+         G2 = H2 - TEMP_KELVIN*S2;
+      } else {
+         S2 += dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
+               dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+         H2 += dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
+               dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
+         G2 = H2 - TEMP_KELVIN*S2;
       }
 
-      else if(isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])) {
-         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
-         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
-         G2 = H2 - TEMP_KELVIN*S2;
-         if(G2 >0) {
-            H2 = _INFINITY;
-            S2 = -1.0;
-            G2 = 1.0;
-         }
-         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-         if(G1<0) {
-            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-            if(T1 < T2 && G2<0) {
-               S1 = S2;
-               H1 = H2;
-               T1 = T2;
-            }
-         } else if(G2<0){
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+      if(G1<0) {
+         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+         if(T1 < T2 && G2<0) {
             S1 = S2;
             H1 = H2;
             T1 = T2;
          }
-      }
-
-      else if(isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
-         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
-         G2 = H2 - TEMP_KELVIN*S2;
-         if(G2>0) {
-            H2 = _INFINITY;
-            S2 = -1.0;
-            G2 = 1.0;
-         }
-         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-         if(G1<0) {
-            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-            if(T1 < T2 && G2<0) {
-               S1 = S2;
-               H1 = H2;
-               T1 = T2;
-            }
-         } else if (G2<0){
-            S1 = S2;
-            H1 = H2;
-            T1 = T2;
-         }
+      } else if(G2<0){
+         S1 = S2;
+         H1 = H2;
+         T1 = T2;
       }
    }
 
@@ -829,17 +783,12 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
    G1 = H1 -TEMP_KELVIN*S1;
    G2 =  H2 -TEMP_KELVIN*S2;
-   if(isFinite(H1)) {
-      if(T1 < T2) {
-         EntropyEnthalpy[0] = S2;
-         EntropyEnthalpy[1] = H2;
-      } else {
-         EntropyEnthalpy[0] = S1;
-         EntropyEnthalpy[1] = H1;
-      }
-   } else {
+   if(T1 < T2) {
       EntropyEnthalpy[0] = S2;
       EntropyEnthalpy[1] = H2;
+   } else {
+      EntropyEnthalpy[0] = S1;
+      EntropyEnthalpy[1] = H1;
    }
    return;
 }

--- a/src/thal.c
+++ b/src/thal.c
@@ -83,7 +83,7 @@ const int MIN_LOOP = 0;
 //                                                  */
 //static const char BASE_PAIRS[4][4] = {"A-T", "C-G", "G-C", "T-A" }; /* allowed basepairs */
 /* matrix for allowed; bp 0 - no bp, watson crick bp - 1 */
-static const int bpIndx[5][5] =  {
+static const int is_complement[5][5] =  {
      {0, 0, 0, 1, 0}, /* A, C, G, T, N; */
      {0, 0, 1, 0, 0},
      {0, 1, 0, 0, 0},
@@ -404,7 +404,7 @@ thal(const unsigned char *oligo_f,
 
       for (; i <= oligo1_len; i++) {
          for (j = 1; j <= oligo2_len; j++) {
-            if(bpIndx[numSeq1[i]][numSeq2[j]]){
+            if(is_complement[numSeq1[i]][numSeq2[j]]){
                RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
                G1 = (enthalpyDPT[i][j]+ SH[1] + dplx_init_H) - TEMP_KELVIN*(entropyDPT[i][j] + SH[0] + dplx_init_S);  
                if(G1<bestG){
@@ -417,7 +417,7 @@ thal(const unsigned char *oligo_f,
       }
 
       /* tracebacking */
-      if(bpIndx[numSeq1[bestI]][numSeq2[bestJ]]){
+      if(is_complement[numSeq1[bestI]][numSeq2[bestJ]]){
          double dH, dS;
          RSH(bestI, bestJ, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
          dH = enthalpyDPT[bestI][bestJ]+ SH[1] + dplx_init_H;
@@ -455,7 +455,7 @@ initMatrix_dimer(double **entropyDPT, double** enthalpyDPT, const unsigned char 
    int i, j;
    for (i = 1; i <= oligo1_len; ++i) {
       for (j = 1; j <= oligo2_len; ++j) {
-         if (bpIndx[numSeq1[i]][numSeq2[j]] == 0)  {
+         if (is_complement[numSeq1[i]][numSeq2[j]] == 0)  {
             enthalpyDPT[i][j] = _INFINITY;
             entropyDPT[i][j] = -1.0;
          } else {
@@ -476,7 +476,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
 
    for (i = 1; i <= oligo1_len; ++i) {
       for (j = 1; j <= oligo2_len; ++j) {
-         if(bpIndx[numSeq1[i]][numSeq2[j]]) { /* if finite */
+         if(is_complement[numSeq1[i]][numSeq2[j]]) { /* if finite */
             LSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
             entropyDPT[i][j] = SH[0];
             enthalpyDPT[i][j] = SH[1];
@@ -485,7 +485,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                saved_RSH[0] = SH[0];
                saved_RSH[1] = SH[1];
 
-               if(bpIndx[numSeq1[i-1]][numSeq2[j-1]]){
+               if(is_complement[numSeq1[i-1]][numSeq2[j-1]]){
                   entropyDPT[i][j] = entropyDPT[i-1][j-1] + stackEntropies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]];
                   enthalpyDPT[i][j] = enthalpyDPT[i-1][j-1] + stackEnthalpies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]];
                   traceback_matrix[i][j].i = i-1;
@@ -500,7 +500,7 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                      jj = 1;
                   }
                   for (; ii > 0 && jj < j; --ii, ++jj) {
-                     if(bpIndx[numSeq1[ii]][numSeq2[jj]]){// (isFinite(enthalpyDPT[ii][jj])) {
+                     if(is_complement[numSeq1[ii]][numSeq2[jj]]){// (isFinite(enthalpyDPT[ii][jj])) {
                         calc_bulge_internal_dimer(ii, jj, i, j, SH, (const double **)entropyDPT, (const double **)enthalpyDPT, numSeq1, numSeq2);
                         newG = SH[1]+saved_RSH[1] -TEMP_KELVIN*(SH[0]+saved_RSH[0]);
                         if(newG < bestG ) {
@@ -564,7 +564,7 @@ calc_bulge_internal_dimer(int i, int j, int ii, int jj, double* EntropyEnthalpy,
         tstack2Entropies[numSeq2[jj]][numSeq2[jj-1]][numSeq1[ii]][numSeq1[ii-1]] + (ILAS * abs(loopSize1 - loopSize2));
       //This check just makes it so that the tstackEnthalpies/Entropies are not needed.
       //The only difference between tstack and tstack2 tables is when both pairs are complementary
-      if((bpIndx[numSeq1[ii]][numSeq2[jj]] && bpIndx[numSeq1[ii-1]][numSeq2[jj-1]]) || (bpIndx[numSeq1[i]][numSeq2[j]] && bpIndx[numSeq1[i+1]][numSeq2[j+1]]))
+      if((is_complement[numSeq1[ii]][numSeq2[jj]] && is_complement[numSeq1[ii-1]][numSeq2[jj-1]]) || (is_complement[numSeq1[i]][numSeq2[j]] && is_complement[numSeq1[i+1]][numSeq2[j+1]]))
          H = _INFINITY;
    }
 
@@ -842,7 +842,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    S1 = S2 = -1.0;
    H1 = H2 = -_INFINITY;
    T1 = T2 = -_INFINITY;
-   if (bpIndx[numSeq1[i]][numSeq2[j]] == 0) {
+   if (is_complement[numSeq1[i]][numSeq2[j]] == 0) {
       EntropyEnthalpy[0] = -1.0;
       EntropyEnthalpy[1] = _INFINITY;
       return;
@@ -856,7 +856,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
       G1 = 1.0;
    }
    /** If there is two dangling ends at the same end of duplex **/
-   if((bpIndx[numSeq1[i-1]][numSeq2[j-1]] != 1 ) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
+   if((is_complement[numSeq1[i-1]][numSeq2[j-1]] != 1 ) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
       S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
         dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
       H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
@@ -880,7 +880,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
          H1 = H2;
          T1 = T2;
       }
-   } else if ((bpIndx[numSeq1[i-1]][numSeq2[j-1]] != 1) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
+   } else if ((is_complement[numSeq1[i-1]][numSeq2[j-1]] != 1) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
       S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
       H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
       G2 = H2 - TEMP_KELVIN*S2;
@@ -902,7 +902,7 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
          H1 = H2;
          T1 = T2;
       }
-   } else if ((bpIndx[numSeq1[i-1]][numSeq2[j-1]] != 1) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
+   } else if ((is_complement[numSeq1[i-1]][numSeq2[j-1]] != 1) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
       S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
       H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
       G2 = H2 - TEMP_KELVIN*S2;
@@ -959,7 +959,7 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    S1 = S2 = -1.0;
    H1 = H2 = _INFINITY;
    T1 = T2 = -_INFINITY;
-   if (bpIndx[numSeq1[i]][numSeq2[j]] == 0) {
+   if (is_complement[numSeq1[i]][numSeq2[j]] == 0) {
       EntropyEnthalpy[0] = -1.0;
       EntropyEnthalpy[1] = _INFINITY;
       return;
@@ -973,7 +973,7 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
       G1 = 1.0;
    }
    
-   if(bpIndx[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
+   if(is_complement[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]]) && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
       S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
         dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
       H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]] +
@@ -1000,7 +1000,7 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
       }
    }
 
-   else if(bpIndx[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])) {
+   else if(is_complement[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]])) {
       S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
       H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq1[i]][numSeq1[i + 1]][numSeq2[j]];
       G2 = H2 - TEMP_KELVIN*S2;
@@ -1024,7 +1024,7 @@ RSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
       }
    }
 
-   else if(bpIndx[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
+   else if(is_complement[numSeq1[i+1]][numSeq2[j+1]] == 0 && isFinite(dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]])) {
       S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
       H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq1[i]][numSeq2[j]][numSeq2[j + 1]];
       G2 = H2 - TEMP_KELVIN*S2;
@@ -1077,7 +1077,7 @@ initMatrix_monomer(double **entropyDPT, double **enthalpyDPT, const unsigned cha
    int i, j;
    for (i = 1; i <= oligo1_len; ++i)
      for (j = i; j <= oligo2_len; ++j)
-       if (j - i < min_hrpn_loop + 1 || (bpIndx[numSeq1[i]][numSeq1[j]] == 0)) {
+       if (j - i < min_hrpn_loop + 1 || (is_complement[numSeq1[i]][numSeq1[j]] == 0)) {
           enthalpyDPT[i][j] = _INFINITY;
           entropyDPT[i][j] = -1.0;
        } else {

--- a/src/thal.c
+++ b/src/thal.c
@@ -280,7 +280,6 @@ thal(const unsigned char *oligo_f,
    int len_f, len_r;
    int k;
    int *bp;
-   unsigned char *oligo2_rev = NULL;
    double mh, ms;
    double G1, bestG;
    jmp_buf _jmp_buf;
@@ -340,17 +339,7 @@ thal(const unsigned char *oligo_f,
       } else {
          RC = R  * log(a->dna_conc/4000000000.0);
       }
-      if(a->type!=3) {
-         oligo2_rev = (unsigned char*) safe_malloc((length_unsig_char(oligo_r) + 1) * sizeof(unsigned char), _jmp_buf, o);
-         strcpy((char*)oligo2_rev,(const char*)oligo_r);
-      } else {
-         oligo2_rev = (unsigned char*) safe_malloc((length_unsig_char(oligo_f) + 1) * sizeof(unsigned char), _jmp_buf, o);
-         strcpy((char*)oligo2_rev,(const char*)oligo_f);
-      }
-      reverse(oligo2_rev); /* REVERSE oligo2, so it goes to dpt 3'->5' direction */
-      free(oligo2);
-      oligo2=NULL;
-      oligo2=&oligo2_rev[0];
+      reverse(oligo2); /* REVERSE oligo2, so it goes to dpt 3'->5' direction */
    }
    /* convert nucleotides to numbers */
    numSeq1 = (unsigned char*) safe_realloc(numSeq1, oligo1_len + 2, _jmp_buf, o);
@@ -426,7 +415,7 @@ thal(const unsigned char *oligo_f,
             }
          }
       }
-      
+
       /* tracebacking */
       if(isFinite(enthalpyDPT[bestI][bestJ])){
          double dH, dS;
@@ -443,7 +432,7 @@ thal(const unsigned char *oligo_f,
       }
       free(ps1);
       free(ps2);
-      free(oligo2_rev);
+      free(oligo2);
       free_DPT(enthalpyDPT);
       free_DPT(entropyDPT);
       free_traceback_matrix(traceback_matrix);

--- a/src/thal.c
+++ b/src/thal.c
@@ -421,10 +421,6 @@ thal(const unsigned char *oligo_f,
       int *ps1, *ps2;
       ps1 = (int*) safe_calloc(oligo1_len, sizeof(int), _jmp_buf, o);
       ps2 = (int*) safe_calloc(oligo2_len, sizeof(int), _jmp_buf, o);
-      for (i = 0; i < oligo1_len; ++i)
-        ps1[i] = 0;
-      for (j = 0; j < oligo2_len; ++j)
-        ps2[j] = 0;
       if(a->type == 2 || a->type == 3)        {
          /* THAL_END1 */
          bestI = bestJ = 0;

--- a/src/thal.c
+++ b/src/thal.c
@@ -446,10 +446,6 @@ thal(const unsigned char *oligo_f,
       dH = enthalpyDPT[bestI][bestJ]+ SH[1] + dplx_init_H;
       dS = (entropyDPT[bestI][bestJ] + SH[0] + dplx_init_S);
       /* tracebacking */
-      for (i = 0; i < oligo1_len; ++i)
-        ps1[i] = 0;
-      for (j = 0; j < oligo2_len; ++j)
-        ps2[j] = 0;
       if(isFinite(enthalpyDPT[bestI][bestJ])){
          traceback_dimer(bestI, bestJ, ps1, ps2, (const struct vec2 **)traceback_matrix);
          o->sec_struct=drawDimer(ps1, ps2, dH, dS, mode, a->temp, oligo1, oligo2, saltCorrection, RC, oligo1_len, oligo2_len, _jmp_buf, o);

--- a/src/thal.c
+++ b/src/thal.c
@@ -485,13 +485,13 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                enthalpyDPT[i][j] = SH[1];
             }
             if (i > 1 && j > 1) {
-               T0 = T1 = -_INFINITY;
                S0 = entropyDPT[i][j];
                H0 = enthalpyDPT[i][j];
                RSH(i, j, SH, RC, dplx_init_S, dplx_init_H, numSeq1, numSeq2);
                saved_RSH[0] = SH[0];
                saved_RSH[1] = SH[1];
                T0 = (H0 + dplx_init_H + SH[1]) /(S0 + dplx_init_S + SH[0] + RC); /* at current position */
+               
                if(isFinite(enthalpyDPT[i-1][j-1]) && isFinite(stackEnthalpies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]])) {
                   S1 = entropyDPT[i-1][j-1] + stackEntropies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]];
                   H1 = enthalpyDPT[i-1][j-1] + stackEnthalpies[numSeq1[i-1]][numSeq1[i]][numSeq2[j-1]][numSeq2[j]];
@@ -499,19 +499,9 @@ fillMatrix_dimer(int maxLoop, double **entropyDPT, double **enthalpyDPT, struct 
                } else {
                   S1 = -1.0;
                   H1 = _INFINITY;
-                  T1 = (H1 + dplx_init_H) /(S1 + dplx_init_S + RC);
+                  T1 = -_INFINITY;
                }
-               
-               if(S1 < MinEntropyCutoff) {
-                  /* to not give dH any value if dS is unreasonable */
-                  S1 = MinEntropy;
-                  H1 = 0.0;
-               }
-               if(S0 < MinEntropyCutoff) {
-                  /* to not give dH any value if dS is unreasonable */
-                  S0 = MinEntropy;
-                  H0 = 0.0;
-               }
+
                if(T1 > T0) { 
                   entropyDPT[i][j] = S1;
                   enthalpyDPT[i][j] = H1;

--- a/src/thal.c
+++ b/src/thal.c
@@ -622,101 +622,49 @@ LSH(int i, int j, double* EntropyEnthalpy, double RC, double dplx_init_S, double
    S1 = atpS[numSeq1[i]][numSeq2[j]] + tstack2Entropies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
    H1 = atpH[numSeq1[i]][numSeq2[j]] + tstack2Enthalpies[numSeq2[j]][numSeq2[j-1]][numSeq1[i]][numSeq1[i-1]];
    G1 = H1 - TEMP_KELVIN*S1;
-   if(G1>0) {
-      H1 = _INFINITY;
-      S1 = -1.0;
-      G1 = 1.0;
-   }
-   /** If there is two dangling ends at the same end of duplex **/
-   if(!is_complement[numSeq1[i-1]][numSeq2[j-1]]){
-      
-      if((numSeq1[i-1] != 4) && (numSeq2[j-1] != 4) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]]) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
-         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
-         dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
-         dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-         G2 = H2 - TEMP_KELVIN*S2;
-         if(G2>0) {
-            H2 = _INFINITY;
-            S2 = -1.0;
-            G2 = 1.0;
-         }
-         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-         if(isFinite(H1) && G1<0) {
-            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-            if(T1<T2 && G2<0) {
-               S1 = S2;
-               H1 = H2;
-               T1 = T2;
-            }
-         } else if(G2<0) {
+   
+   if(!is_complement[numSeq1[i-1]][numSeq2[j-1]]){ 
+      S2 = atpS[numSeq1[i]][numSeq2[j]];
+      H2 = atpH[numSeq1[i]][numSeq2[j]];
+      if ((numSeq1[i-1] == 4)){
+         S2 += dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
+         H2 += dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
+      } else if ((numSeq2[j-1] == 4)){
+         S2 += dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+         H2 += dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+      } else {
+         S2 += dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
+               dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+         H2 += dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]] +
+               dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
+      }
+      G2 = H2 - TEMP_KELVIN*S2;
+      T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
+      if(G1<0) {
+         T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
+         if(T1 < T2  && G2<0) {
             S1 = S2;
             H1 = H2;
             T1 = T2;
          }
-      } else 
-       if ((numSeq1[i-1] == 4) && isFinite(dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]])) {
-         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
-         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies3[numSeq2[j]][numSeq2[j - 1]][numSeq1[i]];
-         G2 = H2 - TEMP_KELVIN*S2;
-         if(G2>0) {
-            H2 = _INFINITY;
-            S2 = -1.0;
-            G2 = 1.0;
-         }
-         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-         if(G1<0) {
-            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-            if(T1<T2 && G2<0) {
-               S1 = S2;
-               H1 = H2;
-               T1 = T2;
-            }
-         } else if (G2<0){
-            S1 = S2;
-            H1 = H2;
-            T1 = T2;
-         }
-      } else if ((numSeq2[j-1] == 4) && isFinite(dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]])) {
-         S2 = atpS[numSeq1[i]][numSeq2[j]] + dangleEntropies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-         H2 = atpH[numSeq1[i]][numSeq2[j]] + dangleEnthalpies5[numSeq2[j]][numSeq1[i]][numSeq1[i - 1]];
-         G2 = H2 - TEMP_KELVIN*S2;
-         if(G2>0) {
-            H2 = _INFINITY;
-            S2 = -1.0;
-            G2 = 1.0;     
-         }
-         T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
-         if(G1<0) {
-            T1 = (H1 + dplx_init_H) / (S1 + dplx_init_S + RC);
-            if(T1 < T2  && G2<0) {
-               S1 = S2;
-               H1 = H2;
-               T1 = T2;
-            }
-         } else if(G2<0) {
-            S1 = S2;
-            H1 = H2;
-            T1 = T2;
-         }
+      } else if(G2<0) {
+         S1 = S2;
+         H1 = H2;
+         T1 = T2;
       }
    }
+   
    S2 = atpS[numSeq1[i]][numSeq2[j]];
    H2 = atpH[numSeq1[i]][numSeq2[j]];
    T2 = (H2 + dplx_init_H) / (S2 + dplx_init_S + RC);
    G1 = H1 -TEMP_KELVIN*S1;   
    G2 = H2 -TEMP_KELVIN*S2;
-   if(isFinite(H1)) {
-      if(T1 < T2) {
-         EntropyEnthalpy[0] = S2;
-         EntropyEnthalpy[1] = H2;
-      } else {
-         EntropyEnthalpy[0] = S1;
-         EntropyEnthalpy[1] = H1;
-      }
-   } else {
+   if(T1 < T2) {
       EntropyEnthalpy[0] = S2;
       EntropyEnthalpy[1] = H2;
+   } else {
+      EntropyEnthalpy[0] = S1;
+      EntropyEnthalpy[1] = H1;
    }
    return;
 }

--- a/src/thal_main.c
+++ b/src/thal_main.c
@@ -54,8 +54,6 @@
 #define OS_WIN
 #endif
 
-#define DEBUG
-
 char *endptr; /* reading input */
 int i; /* index */
 const unsigned char *oligo1, *oligo2; /* inserted oligo sequences */
@@ -73,7 +71,6 @@ int main(int argc, char** argv)
    set_thal_default_args(&a);
    thal_mode mode = THL_GENERAL; /* by default print only melting temperature, 
                                     do not draw structure or print any additional parameters */
-   int thal_debug = 0;
    int thal_only = 0;
 
    usage = "USAGE: %s OPTIONS oligo\n"
@@ -271,17 +268,9 @@ int main(int argc, char** argv)
 
    /* Set the correct mode */
    if (thal_only) {
-     if (thal_debug) {
-       mode = THL_DEBUG_F;
-     } else {
-       mode = THL_FAST;
-     }
+      mode = THL_FAST;
    } else {
-     if (thal_debug) {
-       mode = THL_DEBUG;
-     } else {
-       mode = THL_GENERAL;
-     }
+      mode = THL_GENERAL;
    }
 
    if(interactive) {
@@ -311,7 +300,7 @@ int main(int argc, char** argv)
          tmp_ret = fprintf(stderr, "Error: %s\n", o.msg);
          exit(-1);
        }
-       if((mode == THL_FAST) || (mode == THL_DEBUG_F))
+       if(mode == THL_FAST)
          printf("%f\n",o.temp);
        free(o.sec_struct);
        o.sec_struct=NULL;
@@ -332,7 +321,7 @@ int main(int argc, char** argv)
        tmp_ret = fprintf(stderr, "Error: %s\n", o.msg);
        exit(-1);
      }
-     if((mode == THL_FAST) || (mode == THL_DEBUG_F))
+     if(mode == THL_FAST)
        printf("%f\n",o.temp);
      free(o.sec_struct);
    }

--- a/src/thal_main.c
+++ b/src/thal_main.c
@@ -75,11 +75,6 @@ int main(int argc, char** argv)
                                     do not draw structure or print any additional parameters */
    int thal_debug = 0;
    int thal_only = 0;
-   if((mode == THL_DEBUG) || (mode == THL_DEBUG_F)) {
-#undef DEBUG
-   } else {
-#define DEBUG
-   }
 
    usage = "USAGE: %s OPTIONS oligo\n"
      "-mv monovalent_conc  - concentration of monovalent cations in mM, by default 50 mM\n"
@@ -109,66 +104,50 @@ int main(int argc, char** argv)
      "                       should be provided on one line separated by a comma (dimer only).\n"
      "\n";
    if(argc < 2) {
-#ifdef DEBUG
       fprintf(stderr, usage, argv[0]);
-#endif
       return -1;
    }
    /* BEGIN: READ the INPUT */
    for(i = 1; i < argc; ++i) {
       if (!strncmp("-mv", argv[i], 3)) { /* conc of monovalent cations */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          a.mv = strtod(argv[i+1], &endptr);
          if ('\0' != *endptr || a.mv < 0.0) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          i++;
       } else if (!strncmp("-dv", argv[i], 3)) { /* conc of divalent cations */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          a.dv = strtod(argv[i+1], &endptr);
          if('\0' != *endptr || a.dv < 0.0) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          i++;
       } else if (!strcmp("-path", argv[i])) {
         if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          path = (char*)argv[i+1];
          i++;
       } else if (!strncmp("-s1", argv[i], 3)) { /* first sequence in 5'->3' direction */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          oligo1 = (const unsigned char*)argv[i+1];
          i++;         
       } else if (!strncmp("-s2", argv[i], 3)) { /* second sequence in 5'->3' direction */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          oligo2 = (const unsigned char*)argv[i+1];
@@ -176,9 +155,7 @@ int main(int argc, char** argv)
       } else if (!strncmp("-a", argv[i], 2)) {          /* annealing type END1, END2, ANY, considered only when duplexis; 
                                                   by default ANY  */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          if(strcmp(argv[i+1],"END1")==0) {
@@ -191,24 +168,18 @@ int main(int argc, char** argv)
          } else if (strcmp(argv[i+1], "ANY")==0) {
                a.type = thal_any; /* ANY */  
          } else {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          i++;
       } else if (!strncmp("-d", argv[i], 2)) { /* dna conc */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          a.dna_conc = strtod(argv[i+1], &endptr);
          if('\0' != *endptr || a.dna_conc < 0 || a.dna_conc == 0) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          i++;
@@ -216,68 +187,50 @@ int main(int argc, char** argv)
          thal_only = 1;
       } else if (!strncmp("-t", argv[i], 2)) { /* temperature at which sec str are calculated */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          a.temp = strtod(argv[i+1], &endptr) + ABSOLUTE_ZERO;
          if('\0' != *endptr) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          i++;
       } else if (!strncmp("-n", argv[i], 2)) { /* concentration of dNTPs */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          a.dntp = strtod(argv[i+1], &endptr);
          if('\0' != *endptr || a.dntp < 0.0) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          i++;
       } else if (!strncmp("-maxloop", argv[i], 8)) { /* maximum size of loop calculated; 
                                                       this value can not be larger than 30 */
          if(argv[i+1]==NULL) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          a.maxLoop = (int) (strtod(argv[i+1], &endptr));
                  
          if(a.maxLoop > MAX_LOOP ) {
             a.maxLoop = MAX_LOOP;
-#ifdef DEBUG
             fputs("Warning: the maximum size of secondary structures loop is set to default (30)\n", stderr);
-#endif
          }  else if(a.maxLoop < MIN_LOOP) {         
             a.maxLoop = MIN_LOOP;
-#ifdef DEBUG
             fputs("Warning: the maximum size of secondary structures loop was set to minimum size of allowed loop length (0)\n", stderr);
-#endif
          } 
          if('\0' != *endptr || a.maxLoop < 0) {
-#ifdef DEBUG
             fprintf(stderr, usage, argv[0]);
-#endif
             exit(-1);
          }
          i++;
       } else if (!strncmp("-i", argv[i], 2)) { /* interactive mode */
          interactive = 1;
       } else if(!strncmp("-", argv[i], 1)) { /* Unknown option. */
-#ifdef DEBUG
          fprintf(stderr, usage, argv[0]);
-#endif
          exit(-1);
       } else {
          break;


### PR DESCRIPTION



## Note
This PR includes the changes made in #83. You can see the changes specific to this PR here: https://github.com/DougTownsend/primer3/compare/traceback...DougTownsend:primer3:dimercleanup
## Motivation
I am proposing these changes in order to both improve the performance of `ntthal` and make it easier to read. In the future I want to be able to modify `ntthal` in order to improve the accuracy, but in its current form it can be hard to tell what it is actually doing. I decided to clean it up as much as possible without changing the outputs in order to make future modifications easier and more intuitive. This PR focuses on the code for dimer alignments since that is what I use the most, and it is easier to understand than the hairpin alignments. I will focus on hairpin alignments next.
## Changes
- Removed a lot of dead code (if statements with conditions that were never true, or that did not affect the result if they were).
- Moved repeated code out of if/else blocks.
- Renamed `bpIndx` to `is_complement` to clarify its purpose.
- Replaced the use of `isFinite` with `is_complement` to use integer comparison instead of floating point.
- Added additional if statements to avoid computing values that are not used.
- Added if statement that avoids the need to have separate `tstack` and `tstack2` parameter tables. The only difference between the two is when there are two complementary pairs. Once I make similar changes for hairpin alignments the `tstack` tables will no longer be needed.
- Changed `realloc` calls to `malloc` calls where it made sense.
- Removed `initMatrix_dimer` and put its functionality into `fillMatrix_dimer`.
- Removed unused function arguments.
- Moved the final dH, dS, dG, and Tm calculations out of `drawDimer` and into `thal`. `drawDimer` now only draws dimers.
- Reduced scope of variables in `thal` that are specific to either dimer or hairpin calculations.
- Removed `THL_DEBUG` and `THL_DEBUG_F` modes from thal_main.c. The original `main` had if/else blocks to define and undef the `DEBUG` macro, but that is not how macros work. They are determined at compile time, not based on the control flow at runtime. `DEBUG` was therefore always defined, so I just removed all `#ifdef DEBUG` guards and made `THL_FAST`, `THL_GENERAL`, and `THL_STRUCT` the only modes.
- Moved `drawDimer` and `drawHairpin` to their own section so that the code that calculates the alignments is closer together.
- Fixed indentation.
## Tests and Performance
- Passed all tests in `paranoid_tests.sh`.
- Dimer alignment of 1 million pairs of random length-20 sequences went from 57 seconds down to 43 seconds on my computer.
- `paranoid_tests.sh` went from 107 minutes to 89.5 minutes on my computer.
## Closing
I am sorry for once again submitting such large changes all at once, but I think that this effort will help make Primer3 more maintainable in the long run. Feel free to email me or respond here if you have any questions or concerns about the changes I have made.